### PR TITLE
Audio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(libgwavi 
+	LANGUAGES C
+	HOMEPAGE_URL https://github.com/rolinh/libgwavi
+	DESCRIPTION "libgwavi is a tiny C library aimed at creating AVI files"
+	VERSION 1.0.0
+)
+
+add_compile_options(-Wall -pedantic -D_FILE_OFFSET_BITS=64)
+
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
+add_library(libgwavi SHARED
+	src/avi-utils.c
+	src/fileio.c
+	src/gwavi.c
+)
+
+include(GNUInstallDirs)
+
+target_include_directories(libgwavi PUBLIC inc)
+
+set_target_properties(libgwavi PROPERTIES VERSION ${PROJECT_VERSION} PUBLIC_HEADER inc/gwavi.h)
+
+configure_file(libgwavi.pc.in libgwavi.pc @ONLY) 
+
+install(TARGETS libgwavi
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+	)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libgwavi.pc DESTINATION lib/pkgconfig)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ library to be reliable. So here is what has already changed from `libkohn-avi`:
 This library has no dependencies, you only need the standard C library.
 To generate `libgwavi.so`, just type the following from the root's directory:
 
-    make
+    mkdir build
+    cd build
+    cmake ..
+    make install
 
 To generate the documentation of the library functions, type the following:
 

--- a/README.md
+++ b/README.md
@@ -87,11 +87,7 @@ Note! You may need to declare this BEFORE running `gwavi_open()`.
 For example:
 ```c
 struct gwavi_t *gwavi;
-struct gwavi_audio_t audio = {
-        .channels = 2,
-        .bits = 16,
-        .samples_per_second = 44100
-};
+struct gwavi_audio_t audio;
 
 gwavi = gwavi_open("foo.avi",
                    1920,

--- a/inc/gwavi.h
+++ b/inc/gwavi.h
@@ -42,7 +42,7 @@ struct gwavi_audio_t;
 /* Main ibrary functions */
 struct gwavi_t *gwavi_open(const char *filename, unsigned int width,
 			   unsigned int height, const char *fourcc, unsigned int fps,
-			   struct gwavi_audio_t *audio);
+			   int use_audio);
 int gwavi_add_frame(struct gwavi_t *gwavi, const unsigned char *buffer, size_t len);
 int gwavi_add_audio(struct gwavi_t *gwavi, const unsigned char *buffer, size_t len);
 int gwavi_close(struct gwavi_t *gwavi);
@@ -57,6 +57,8 @@ int gwavi_set_framerate(struct gwavi_t *gwavi, unsigned int fps);
 int gwavi_set_codec(struct gwavi_t *gwavi, const char *fourcc);
 int gwavi_set_size(struct gwavi_t *gwavi, unsigned int width,
 		    unsigned int height);
+int gwavi_set_audio_parameters(struct gwavi_t *gwavi, unsigned bits, unsigned
+		channels, unsigned sample_rate);
 
 #endif /* ndef H_GWAVI */
 

--- a/libgwavi.pc.in
+++ b/libgwavi.pc.in
@@ -1,0 +1,12 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/lib"
+includedir="${prefix}/include"
+
+Name: @PROJECT_NAME@
+Description: @CMAKE_PROJECT_DESCRIPTION@
+URL: @CMAKE_PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Requires: @pc_req_public@
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -llibgwavi


### PR DESCRIPTION
Setting audio-parameters is now through a function call as the structure definition was a private and could thus not be used in practice (at least in c++).